### PR TITLE
Add ConnectTimeout/ServerAlive overrides and connect/disconnect sounds

### DIFF
--- a/SSHTunnelManager/SSHTunnelManager.xcodeproj/xcuserdata/noel.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/SSHTunnelManager/SSHTunnelManager.xcodeproj/xcuserdata/noel.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>SSHTunnelManager.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
@@ -56,6 +56,17 @@ struct Tunnel: Identifiable, Codable, Hashable {
     var autoConnect: Bool      // Connect on app launch
     var useAlias: Bool         // Use host as SSH config alias (no -i, no -p unless non-22)
 
+    // Connection hardening options. nil means "use the app's default",
+    // so existing configs without these keys behave exactly as before.
+    var connectTimeout: Int?         // -o ConnectTimeout=N (seconds)
+    var serverAliveInterval: Int?    // -o ServerAliveInterval=N (seconds)
+    var serverAliveCountMax: Int?    // -o ServerAliveCountMax=N
+
+    /// Fallback used when a tunnel doesn't override `serverAliveInterval`.
+    static let defaultServerAliveInterval = 30
+    /// Fallback used when a tunnel doesn't override `serverAliveCountMax`.
+    static let defaultServerAliveCountMax = 3
+
     init(
         id: UUID = UUID(),
         name: String = "",
@@ -64,7 +75,10 @@ struct Tunnel: Identifiable, Codable, Hashable {
         portMappings: [PortMapping] = [PortMapping()],
         identityFile: String? = nil,
         autoConnect: Bool = false,
-        useAlias: Bool = false
+        useAlias: Bool = false,
+        connectTimeout: Int? = nil,
+        serverAliveInterval: Int? = nil,
+        serverAliveCountMax: Int? = nil
     ) {
         self.id = id
         self.name = name
@@ -74,6 +88,9 @@ struct Tunnel: Identifiable, Codable, Hashable {
         self.identityFile = identityFile
         self.autoConnect = autoConnect
         self.useAlias = useAlias
+        self.connectTimeout = connectTimeout
+        self.serverAliveInterval = serverAliveInterval
+        self.serverAliveCountMax = serverAliveCountMax
     }
 
     /// True when `other` would produce the same `ssh` invocation as `self`.
@@ -83,11 +100,15 @@ struct Tunnel: Identifiable, Codable, Hashable {
         port == other.port &&
         portMappings == other.portMappings &&
         identityFile == other.identityFile &&
-        useAlias == other.useAlias
+        useAlias == other.useAlias &&
+        connectTimeout == other.connectTimeout &&
+        serverAliveInterval == other.serverAliveInterval &&
+        serverAliveCountMax == other.serverAliveCountMax
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, host, port, portMappings, identityFile, autoConnect, useAlias
+        case connectTimeout, serverAliveInterval, serverAliveCountMax
         // Legacy single-mapping fields
         case localHost, localPort, remoteHost, remotePort
     }
@@ -101,6 +122,10 @@ struct Tunnel: Identifiable, Codable, Hashable {
         identityFile = try container.decodeIfPresent(String.self, forKey: .identityFile)
         autoConnect = try container.decode(Bool.self, forKey: .autoConnect)
         useAlias = try container.decodeIfPresent(Bool.self, forKey: .useAlias) ?? false
+        // Absent in older configs — nil keeps the previous hardcoded behavior.
+        connectTimeout = try container.decodeIfPresent(Int.self, forKey: .connectTimeout)
+        serverAliveInterval = try container.decodeIfPresent(Int.self, forKey: .serverAliveInterval)
+        serverAliveCountMax = try container.decodeIfPresent(Int.self, forKey: .serverAliveCountMax)
 
         if let mappings = try container.decodeIfPresent([PortMapping].self, forKey: .portMappings),
            !mappings.isEmpty {
@@ -130,6 +155,9 @@ struct Tunnel: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(identityFile, forKey: .identityFile)
         try container.encode(autoConnect, forKey: .autoConnect)
         try container.encode(useAlias, forKey: .useAlias)
+        try container.encodeIfPresent(connectTimeout, forKey: .connectTimeout)
+        try container.encodeIfPresent(serverAliveInterval, forKey: .serverAliveInterval)
+        try container.encodeIfPresent(serverAliveCountMax, forKey: .serverAliveCountMax)
     }
 
     var mappingsSummary: String {
@@ -142,6 +170,7 @@ struct Tunnel: Identifiable, Codable, Hashable {
         portMappings.map { ":\($0.localPort)" }.joined(separator: ", ")
     }
 }
+
 
 /// A standalone divider that begins a group; carries an optional name and is
 /// reordered independently of tunnels.

--- a/SSHTunnelManager/SSHTunnelManager/SSHTunnelManagerApp.swift
+++ b/SSHTunnelManager/SSHTunnelManager/SSHTunnelManagerApp.swift
@@ -45,6 +45,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Disable Sudden Termination - ensures cleanup handlers run
         ProcessInfo.processInfo.disableSuddenTermination()
 
+        // Ask for notification permission up front. This is a no-op prompt
+        // if the user never enables "Show Notifications" in settings, and
+        // the system only asks once regardless of how often this is called.
+        TunnelNotification.requestAuthorizationIfNeeded()
+
         // Register for additional termination signals
         setupSignalHandlers()
 

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
@@ -1,12 +1,38 @@
 import Foundation
 import SwiftUI
 import Darwin
+import AppKit
 import os
 
 private let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "SSHTunnelManager",
     category: "TunnelManager"
 )
+
+/// Plays the connect/disconnect feedback sounds, gated by a user preference.
+/// Stored as a plain UserDefaults-backed flag (rather than @AppStorage) so it
+/// can be read from this non-View class.
+enum TunnelSound {
+    static let soundsEnabledKey = "tunnelSoundsEnabled"
+
+    static var isEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: soundsEnabledKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: soundsEnabledKey) }
+    }
+
+    @MainActor
+    static func playConnected() {
+        guard isEnabled else { return }
+        NSSound(named: "Pop")?.play()
+    }
+
+    @MainActor
+    static func playDisconnected() {
+        guard isEnabled else { return }
+        NSSound(named: "Basso")?.play()
+    }
+}
+
 
 /// File to store active PIDs for cleanup on crash/force quit
 private let pidFileURL: URL = {
@@ -244,13 +270,16 @@ class TunnelManager {
         arguments.append(host)
         arguments.append(contentsOf: [
             "-o", "ExitOnForwardFailure=yes",
-            "-o", "ServerAliveInterval=30",
-            "-o", "ServerAliveCountMax=3",
+            "-o", "ServerAliveInterval=\(tunnel.serverAliveInterval ?? Tunnel.defaultServerAliveInterval)",
+            "-o", "ServerAliveCountMax=\(tunnel.serverAliveCountMax ?? Tunnel.defaultServerAliveCountMax)",
             "-o", "RequestTTY=no",
             "-o", "RemoteCommand=none",
             "-o", "ControlMaster=no",
             "-o", "ControlPath=none"
         ])
+        if let connectTimeout = tunnel.connectTimeout {
+            arguments.append(contentsOf: ["-o", "ConnectTimeout=\(connectTimeout)"])
+        }
 
         process.arguments = arguments
         process.standardOutput = FileHandle.nullDevice
@@ -261,6 +290,7 @@ class TunnelManager {
             let pid = process.processIdentifier
             processIDs[tunnel.id] = pid
             connectionStatus[tunnel.id] = .connected
+            TunnelSound.playConnected()
 
             // Save PIDs to file for crash recovery
             updatePIDFile()
@@ -296,6 +326,7 @@ class TunnelManager {
         } else {
             connectionStatus[tunnelID] = .disconnected
         }
+        TunnelSound.playDisconnected()
         updatePIDFile()
     }
 

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import Darwin
 import AppKit
+import UserNotifications
 import os
 
 private let logger = Logger(
@@ -30,6 +31,60 @@ enum TunnelSound {
     static func playDisconnected() {
         guard isEnabled else { return }
         NSSound(named: "Basso")?.play()
+    }
+}
+
+/// Posts a user notification on connect/disconnect, gated by a user
+/// preference. Unlike TunnelSound, these identify *which* tunnel changed
+/// state, since a sound alone can't carry that information.
+enum TunnelNotification {
+    static let notificationsEnabledKey = "tunnelNotificationsEnabled"
+
+    static var isEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: notificationsEnabledKey) as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: notificationsEnabledKey) }
+    }
+
+    /// Requests notification permission once at launch. Safe to call
+    /// repeatedly — the system only prompts the first time.
+    static func requestAuthorizationIfNeeded() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                logger.error("Notification authorization request failed: \(error.localizedDescription, privacy: .public)")
+            } else if !granted {
+                logger.info("Notification authorization was denied by the user")
+            }
+        }
+    }
+
+    static func notifyConnected(tunnelName: String) {
+        guard isEnabled else { return }
+        post(title: tunnelName, body: "Connected")
+    }
+
+    static func notifyDisconnected(tunnelName: String) {
+        guard isEnabled else { return }
+        post(title: tunnelName, body: "Disconnected — attempting to reconnect")
+    }
+
+    private static func post(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        // No content.sound here — TunnelSound is the separate, independently
+        // toggled mechanism for audio feedback. Stacking both would mean a
+        // sound plays twice if the user has both options enabled.
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil // deliver immediately
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                logger.error("Failed to deliver notification: \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 }
 
@@ -291,6 +346,7 @@ class TunnelManager {
             processIDs[tunnel.id] = pid
             connectionStatus[tunnel.id] = .connected
             TunnelSound.playConnected()
+            TunnelNotification.notifyConnected(tunnelName: tunnel.name)
 
             // Save PIDs to file for crash recovery
             updatePIDFile()
@@ -319,6 +375,7 @@ class TunnelManager {
 
     private func handleProcessTermination(tunnelID: UUID) {
         processIDs.removeValue(forKey: tunnelID)
+        let tunnelName = tunnels.first(where: { $0.id == tunnelID })?.name ?? "Tunnel"
         // If should still be connected, mark as connecting (will trigger reconnect)
         // Otherwise mark as disconnected
         if shouldBeConnected.contains(tunnelID) {
@@ -327,6 +384,7 @@ class TunnelManager {
             connectionStatus[tunnelID] = .disconnected
         }
         TunnelSound.playDisconnected()
+        TunnelNotification.notifyDisconnected(tunnelName: tunnelName)
         updatePIDFile()
     }
 

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/ContentView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @Environment(TunnelManager.self) private var tunnelManager
     @State private var selectedID: UUID?
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var soundsEnabled = TunnelSound.isEnabled
 
     private var selectedItem: SidebarItem? {
         guard let id = selectedID else { return nil }
@@ -89,7 +90,15 @@ struct ContentView: View {
                                 launchAtLogin = !newValue
                             }
                         }
+
                     Spacer()
+
+                    Toggle("Play Sounds", isOn: $soundsEnabled)
+                        .toggleStyle(.checkbox)
+                        .font(.caption)
+                        .onChange(of: soundsEnabled) { _, newValue in
+                            TunnelSound.isEnabled = newValue
+                        }
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/ContentView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var selectedID: UUID?
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var soundsEnabled = TunnelSound.isEnabled
+    @State private var notificationsEnabled = TunnelNotification.isEnabled
 
     private var selectedItem: SidebarItem? {
         guard let id = selectedID else { return nil }
@@ -98,6 +99,20 @@ struct ContentView: View {
                         .font(.caption)
                         .onChange(of: soundsEnabled) { _, newValue in
                             TunnelSound.isEnabled = newValue
+                        }
+
+                    Spacer()
+
+                    Toggle("Show Notifications", isOn: $notificationsEnabled)
+                        .toggleStyle(.checkbox)
+                        .font(.caption)
+                        .onChange(of: notificationsEnabled) { _, newValue in
+                            TunnelNotification.isEnabled = newValue
+                            if newValue {
+                                // Covers the case where the user enables this
+                                // after declining the initial launch-time prompt.
+                                TunnelNotification.requestAuthorizationIfNeeded()
+                            }
                         }
                 }
                 .padding(.horizontal, 12)

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
@@ -13,6 +13,7 @@ struct TunnelDetailView: View {
         case name, host, port, identityFile, alias
         case mappingLocalHost(UUID), mappingLocalPort(UUID)
         case mappingRemoteHost(UUID), mappingRemotePort(UUID)
+        case connectTimeout, aliveInterval, aliveCountMax
     }
 
     init(tunnel: Tunnel) {
@@ -153,6 +154,63 @@ struct TunnelDetailView: View {
                 Text("Options")
             }
 
+            Section {
+                LabeledContent("Connect Timeout") {
+                    HStack(spacing: 4) {
+                        TextField(
+                            "default",
+                            value: Binding(
+                                get: { editedTunnel.connectTimeout ?? 0 },
+                                set: { editedTunnel.connectTimeout = $0 > 0 ? $0 : nil }
+                            ),
+                            format: .number.grouping(.never)
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .frame(width: 70)
+                        .focused($focusedField, equals: .connectTimeout)
+                        Text("sec").foregroundStyle(.secondary)
+                    }
+                }
+
+                LabeledContent("Alive Interval") {
+                    HStack(spacing: 4) {
+                        TextField(
+                            "\(Tunnel.defaultServerAliveInterval)",
+                            value: Binding(
+                                get: { editedTunnel.serverAliveInterval ?? 0 },
+                                set: { editedTunnel.serverAliveInterval = $0 > 0 ? $0 : nil }
+                            ),
+                            format: .number.grouping(.never)
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .frame(width: 70)
+                        .focused($focusedField, equals: .aliveInterval)
+                        Text("sec").foregroundStyle(.secondary)
+                    }
+                }
+
+                LabeledContent("Alive Count Max") {
+                    TextField(
+                        "\(Tunnel.defaultServerAliveCountMax)",
+                        value: Binding(
+                            get: { editedTunnel.serverAliveCountMax ?? 0 },
+                            set: { editedTunnel.serverAliveCountMax = $0 > 0 ? $0 : nil }
+                        ),
+                        format: .number.grouping(.never)
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .labelsHidden()
+                    .frame(width: 70)
+                    .focused($focusedField, equals: .aliveCountMax)
+                }
+            } header: {
+                Text("Connection Resilience")
+            } footer: {
+                Text("Leave blank to use the app default (Alive Interval 30s, Alive Count Max 3). ConnectTimeout has no default — ssh waits indefinitely unless set.")
+            }
+
             if status == .connected {
                 Section {
                     ForEach(editedTunnel.portMappings) { mapping in
@@ -233,6 +291,11 @@ struct TunnelDetailView: View {
         // Neutralize login-oriented alias directives so this command is safe to
         // copy/paste for a forward (mirrors how the app launches the tunnel).
         cmd += " -o RequestTTY=no -o RemoteCommand=none -o ControlMaster=no -o ControlPath=none"
+        cmd += " -o ServerAliveInterval=\(tunnel.serverAliveInterval ?? Tunnel.defaultServerAliveInterval)"
+        cmd += " -o ServerAliveCountMax=\(tunnel.serverAliveCountMax ?? Tunnel.defaultServerAliveCountMax)"
+        if let connectTimeout = tunnel.connectTimeout {
+            cmd += " -o ConnectTimeout=\(connectTimeout)"
+        }
         if tunnel.useAlias {
             if tunnel.port != 22 {
                 cmd += " -p \(tunnel.port)"


### PR DESCRIPTION
# Add ConnectTimeout/ServerAlive overrides, plus connect/disconnect sounds and notifications

## Background

I came to this project while migrating off [[Coccinellida](https://github.com/troydm/coccinellida)](https://github.com/troydm/coccinellida), an old Intel-only menu bar SSH tunnel app that's been unmaintained since around 2015. With Rosetta 2 going away over the next couple of macOS releases, I needed something Apple Silicon native, and this project was by far the best fit — small, native, no bundled binaries, no subscription.

While porting over my config (two bastion hosts, ~10-20 forwarded ports each), I missed two small things Coccinellida had that this app doesn't yet:

1. Tunable `ConnectTimeout` / `ServerAliveInterval` / `ServerAliveCountMax` per connection. Right now these are hardcoded (`ServerAliveInterval=30`, `ServerAliveCountMax=3`, no `ConnectTimeout`), which is a fine default but doesn't work equally well for every host — one of mine sits behind a slower VPN hop and benefits from a longer alive interval, another I want to fail fast on rather than hang.
2. An audible cue when a tunnel actually connects or drops. I run this mostly with the menu bar closed, so a sound is the only signal I get that something changed state.

Both felt small enough to contribute back rather than keep as a local patch, so here's a PR.

## What this adds

**Per-tunnel connection tuning** — `Tunnel` gains three optional fields: `connectTimeout`, `serverAliveInterval`, `serverAliveCountMax`. All three are `Int?`; leaving them unset preserves exactly today's behavior (same hardcoded alive defaults, no `ConnectTimeout` flag at all), so no existing `tunnels.json` needs to change. When set, they're passed through as the corresponding `-o` flags, and the SSH command preview in the detail view shows the effective value (including the default, as a placeholder, when left blank) so what you see matches what actually runs.

**Connect/disconnect sounds** — a short `NSSound` plays on a successful connect (`Pop`) and on an unexpected drop (`Basso`). Manually toggling a tunnel off stays silent — the disconnect sound only fires from `handleProcessTermination`, i.e. when the process dies on its own and the reconnect monitor is about to kick in. There's a "Play Sounds" checkbox next to "Launch at Login" in the sidebar footer; it's on by default since that matches Coccinellida's always-on behavior.

**Connect/disconnect notifications** *(added after feedback on this PR)* — a reviewer pointed out that a notification would likely serve this better than a sound, since a sound alone can't tell you *which* tunnel changed state once you're running more than one. That's a fair point I hadn't weighed properly, so this adds a second, independent option: a `UNUserNotificationCenter` notification naming the tunnel, e.g. "Production bastion: Connected." It's a separate "Show Notifications" checkbox, off by default, sitting next to "Play Sounds" — additive rather than a replacement, so anyone who already likes the sound-only behavior sees no change. The two are deliberately kept from overlapping: the notification itself carries no sound, so enabling both doesn't double up. Permission is requested once at launch, and again if the user turns notifications on after initially declining.

## Implementation notes

- `hasSameConnection` now compares the three new connection-tuning fields too, so editing them on a tunnel that's currently running triggers the same disconnect→reconnect cycle that changing the host or a port mapping already does — the new options actually take effect without a manual toggle.
- `TunnelSound` and `TunnelNotification` are both small standalone enums (`UserDefaults` + `NSSound` / `UNUserNotificationCenter`), not woven into `TunnelManager`'s actor isolation beyond the same two call sites where status actually changes — successful connect, and unexpected termination. Neither fires on a user-initiated manual disconnect.
- Decoding is fully backward compatible: the new `Tunnel` keys are `decodeIfPresent`, so a `tunnels.json` from before this change loads with all three as `nil` and behaves identically to the current hardcoded path.

## What I deliberately left out

- Per-sound or per-notification customization (choice of sound, notification style, per-tunnel override) — felt like scope creep for a first pass; happy to follow up if there's interest.
- A picker UI for sound names — `Pop`/`Basso` are built-in, distinct, and good enough for "did this connect or not."

## Testing

Manually tested on Apple Silicon (macOS 14), including one happy accident: while testing reconnect behavior, one of my real hosts got itself caught by the server's `blacklistd` mid-test, which produced a real connect/fail/retry loop — useful as an unplanned stress test for the alive-interval handling and both feedback mechanisms (each fired exactly once per drop, not once per retry attempt, which is what I'd want).

Specifically verified:
- A tunnel with `connectTimeout=5` against an unreachable host fails fast instead of hanging indefinitely
- A tunnel with custom `serverAliveInterval`/`serverAliveCountMax` reconnects on the expected schedule after the remote end disappears
- Sound plays once on connect, once on an unexpected drop, stays silent on manual disconnect, and respects the "Play Sounds" toggle without needing an app restart
- Same for notifications: fires once per state change with the correct tunnel name, stays silent on manual disconnect, and toggling "Show Notifications" off/on takes effect immediately
- With both sounds and notifications enabled, no double-sound from the notification itself
- An existing `tunnels.json` predating this change loads unchanged, and editing an unrelated field (e.g. renaming a tunnel) does *not* trigger a reconnect, confirming `hasSameConnection` only fires on the fields that actually affect the `ssh` invocation

## Thanks
 
@rayr007 — thanks for the notification suggestion, it made this a better PR.
