### PR TITLE
Add Compression and TCP Keep-Alive options

### DIFF
--- a/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
@@ -62,6 +62,15 @@ struct Tunnel: Identifiable, Codable, Hashable {
     var serverAliveInterval: Int?    // -o ServerAliveInterval=N (seconds)
     var serverAliveCountMax: Int?    // -o ServerAliveCountMax=N
 
+    // Simple on/off connection options. Unlike the Int? options above these
+    // have an unambiguous "off" state, so a plain Bool (defaulting to false)
+    // is enough — no separate "use app default" case to represent.
+    var compression: Bool      // -C (compress the data stream)
+    var tcpKeepAlive: Bool     // -o TCPKeepAlive=yes — a lower-level signal
+                                // than ServerAliveInterval/CountMax above: TCP-
+                                // level dead-path detection vs. an
+                                // ssh-protocol-level liveness check.
+
     /// Fallback used when a tunnel doesn't override `serverAliveInterval`.
     static let defaultServerAliveInterval = 30
     /// Fallback used when a tunnel doesn't override `serverAliveCountMax`.
@@ -78,7 +87,9 @@ struct Tunnel: Identifiable, Codable, Hashable {
         useAlias: Bool = false,
         connectTimeout: Int? = nil,
         serverAliveInterval: Int? = nil,
-        serverAliveCountMax: Int? = nil
+        serverAliveCountMax: Int? = nil,
+        compression: Bool = false,
+        tcpKeepAlive: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -91,6 +102,8 @@ struct Tunnel: Identifiable, Codable, Hashable {
         self.connectTimeout = connectTimeout
         self.serverAliveInterval = serverAliveInterval
         self.serverAliveCountMax = serverAliveCountMax
+        self.compression = compression
+        self.tcpKeepAlive = tcpKeepAlive
     }
 
     /// True when `other` would produce the same `ssh` invocation as `self`.
@@ -103,12 +116,15 @@ struct Tunnel: Identifiable, Codable, Hashable {
         useAlias == other.useAlias &&
         connectTimeout == other.connectTimeout &&
         serverAliveInterval == other.serverAliveInterval &&
-        serverAliveCountMax == other.serverAliveCountMax
+        serverAliveCountMax == other.serverAliveCountMax &&
+        compression == other.compression &&
+        tcpKeepAlive == other.tcpKeepAlive
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, host, port, portMappings, identityFile, autoConnect, useAlias
         case connectTimeout, serverAliveInterval, serverAliveCountMax
+        case compression, tcpKeepAlive
         // Legacy single-mapping fields
         case localHost, localPort, remoteHost, remotePort
     }
@@ -126,6 +142,10 @@ struct Tunnel: Identifiable, Codable, Hashable {
         connectTimeout = try container.decodeIfPresent(Int.self, forKey: .connectTimeout)
         serverAliveInterval = try container.decodeIfPresent(Int.self, forKey: .serverAliveInterval)
         serverAliveCountMax = try container.decodeIfPresent(Int.self, forKey: .serverAliveCountMax)
+        // Absent in older configs — false matches today's behavior (neither
+        // flag is currently passed to ssh at all).
+        compression = try container.decodeIfPresent(Bool.self, forKey: .compression) ?? false
+        tcpKeepAlive = try container.decodeIfPresent(Bool.self, forKey: .tcpKeepAlive) ?? false
 
         if let mappings = try container.decodeIfPresent([PortMapping].self, forKey: .portMappings),
            !mappings.isEmpty {
@@ -158,6 +178,8 @@ struct Tunnel: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(connectTimeout, forKey: .connectTimeout)
         try container.encodeIfPresent(serverAliveInterval, forKey: .serverAliveInterval)
         try container.encodeIfPresent(serverAliveCountMax, forKey: .serverAliveCountMax)
+        try container.encode(compression, forKey: .compression)
+        try container.encode(tcpKeepAlive, forKey: .tcpKeepAlive)
     }
 
     var mappingsSummary: String {

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
@@ -335,6 +335,12 @@ class TunnelManager {
         if !tunnel.useAlias || tunnel.port != 22 {
             arguments.append(contentsOf: ["-p", "\(tunnel.port)"])
         }
+        if tunnel.compression {
+            arguments.append("-C")
+        }
+        if tunnel.tcpKeepAlive {
+            arguments.append(contentsOf: ["-o", "TCPKeepAlive=yes"])
+        }
 
         // Destination, then robustness/hardening options. Forcing a dedicated,
         // forward-only connection (RequestTTY / RemoteCommand / ControlMaster /

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
@@ -202,6 +202,15 @@ struct TunnelDetailView: View {
                 Text("A blank field uses its placeholder default; hover a field for what it does. Connect Timeout is off unless set.")
             }
 
+            Section {
+                Toggle("Compression", isOn: $editedTunnel.compression)
+                    .help("Compress the data stream (-C). Can help on slow links; costs CPU.")
+                Toggle("TCP Keep-Alive", isOn: $editedTunnel.tcpKeepAlive)
+                    .help("Lower-level than Alive Interval above — detects a dead network path rather than an unresponsive ssh server.")
+            } header: {
+                Text("Advanced")
+            }
+
             if status == .connected {
                 Section {
                     ForEach(editedTunnel.portMappings) { mapping in
@@ -286,6 +295,12 @@ struct TunnelDetailView: View {
         cmd += " -o ServerAliveCountMax=\(tunnel.serverAliveCountMax ?? Tunnel.defaultServerAliveCountMax)"
         if let connectTimeout = tunnel.connectTimeout {
             cmd += " -o ConnectTimeout=\(connectTimeout)"
+        }
+        if tunnel.compression {
+            cmd += " -C"
+        }
+        if tunnel.tcpKeepAlive {
+            cmd += " -o TCPKeepAlive=yes"
         }
         if tunnel.useAlias {
             if tunnel.port != 22 {


### PR DESCRIPTION
# Add Compression and TCP Keep-Alive options
 
First off, thanks for shipping and polishing #5 so quickly — the local-port-open
polling for accurate connect/disconnect cues, the Preferences popover, and the
ad-hoc signing fix were all things I hadn't thought through nearly as carefully.
Appreciate you taking the time to refine it rather than just merging as-is.
 
## What this adds
 
Two more small per-tunnel options, also carried over from Coccinellida while finishing
up that migration:
 
- **`compression`** — passes `-C` to ssh (compress the data stream). Useful on slow
  links, costs some CPU; off by default.
- **`tcpKeepAlive`** — passes `-o TCPKeepAlive=yes`. This is a lower-level signal than
  `ServerAliveInterval`/`ServerAliveCountMax` (TCP-level dead-path detection vs. an
  ssh-protocol-level liveness check), so I kept it as its own option rather than
  folding it into the existing Connection Resilience fields.
Both default to `false`, matching today's behavior exactly — neither flag is passed
currently, so existing `tunnels.json` files are unaffected.
 
## Implementation notes
 
- `hasSameConnection` now includes both fields, so toggling either on a running tunnel
  triggers the same disconnect→reconnect cycle as the other connection options.
- UI: a new "Advanced" section in `TunnelDetailView`, right below Connection Resilience,
  with a `.help()` tooltip on each toggle — matching the style you introduced there.
- The SSH command preview reflects both flags when enabled.
## What I left out
 
No UI for other `-o` compression-related tuning (e.g. `CompressionLevel`, which is
SSH protocol 1 only and long deprecated) — `-C` alone covers the useful case.
 
## Testing
 
Manually tested on Apple Silicon (macOS 14):
- A tunnel with `compression` on shows `-C` in the command preview and in the actual
  `ps`-visible ssh invocation
- A tunnel with `tcpKeepAlive` on shows `-o TCPKeepAlive=yes` likewise
- Toggling either on a connected tunnel triggers a reconnect with the new flag applied
- An existing `tunnels.json` without these keys loads with both `false`, identical to
  pre-PR behavior
 