### PR TITLE
Add Remote Forward (-R) and ProxyJump (-J)

### DIFF
--- a/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
@@ -3,6 +3,9 @@ import Foundation
 /// How a port mapping forwards traffic.
 enum ForwardType: String, Codable, Hashable {
     case local      // ssh -L : a fixed local→remote port forward
+    case remote     // ssh -R : a fixed remote→local port forward (the remote
+                    // host binds the port; traffic arriving there is sent
+                    // back to this Mac)
     case dynamic    // ssh -D : a SOCKS proxy (destinations chosen per request)
 }
 
@@ -73,6 +76,11 @@ struct Tunnel: Identifiable, Codable, Hashable {
                                    // insecure: skips host-key verification, for hosts recreated
                                    // on the same address.
 
+    // -J host[:port][,host2[:port2]...] — hop through one or more
+    // intermediate hosts to reach `host`, replacing a manual multi-hop ssh.
+    // nil/empty means "connect directly", matching today's behavior.
+    var proxyJump: String?
+
     /// Fallback used when a tunnel doesn't override `serverAliveInterval`.
     static let defaultServerAliveInterval = 30
     /// Fallback used when a tunnel doesn't override `serverAliveCountMax`.
@@ -92,7 +100,8 @@ struct Tunnel: Identifiable, Codable, Hashable {
         serverAliveCountMax: Int? = nil,
         compression: Bool = false,
         disableTCPKeepAlive: Bool = false,
-        skipHostKeyCheck: Bool = false
+        skipHostKeyCheck: Bool = false,
+        proxyJump: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -108,6 +117,7 @@ struct Tunnel: Identifiable, Codable, Hashable {
         self.compression = compression
         self.disableTCPKeepAlive = disableTCPKeepAlive
         self.skipHostKeyCheck = skipHostKeyCheck
+        self.proxyJump = proxyJump
     }
 
     /// True when `other` would produce the same `ssh` invocation as `self`.
@@ -123,13 +133,14 @@ struct Tunnel: Identifiable, Codable, Hashable {
         serverAliveCountMax == other.serverAliveCountMax &&
         compression == other.compression &&
         disableTCPKeepAlive == other.disableTCPKeepAlive &&
-        skipHostKeyCheck == other.skipHostKeyCheck
+        skipHostKeyCheck == other.skipHostKeyCheck &&
+        proxyJump == other.proxyJump
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, host, port, portMappings, identityFile, autoConnect, useAlias
         case connectTimeout, serverAliveInterval, serverAliveCountMax
-        case compression, disableTCPKeepAlive, skipHostKeyCheck
+        case compression, disableTCPKeepAlive, skipHostKeyCheck, proxyJump
         // Legacy single-mapping fields
         case localHost, localPort, remoteHost, remotePort
     }
@@ -152,6 +163,8 @@ struct Tunnel: Identifiable, Codable, Hashable {
         compression = try container.decodeIfPresent(Bool.self, forKey: .compression) ?? false
         disableTCPKeepAlive = try container.decodeIfPresent(Bool.self, forKey: .disableTCPKeepAlive) ?? false
         skipHostKeyCheck = try container.decodeIfPresent(Bool.self, forKey: .skipHostKeyCheck) ?? false
+        // Absent in older configs — nil means "connect directly", i.e. no -J.
+        proxyJump = try container.decodeIfPresent(String.self, forKey: .proxyJump)
 
         if let mappings = try container.decodeIfPresent([PortMapping].self, forKey: .portMappings),
            !mappings.isEmpty {
@@ -187,11 +200,16 @@ struct Tunnel: Identifiable, Codable, Hashable {
         try container.encode(compression, forKey: .compression)
         try container.encode(disableTCPKeepAlive, forKey: .disableTCPKeepAlive)
         try container.encode(skipHostKeyCheck, forKey: .skipHostKeyCheck)
+        try container.encodeIfPresent(proxyJump, forKey: .proxyJump)
     }
 
     var mappingsSummary: String {
         portMappings.map { m in
-            m.forward == .dynamic ? "SOCKS :\(m.localPort)" : ":\(m.localPort) → :\(m.remotePort)"
+            switch m.forward {
+            case .dynamic: return "SOCKS :\(m.localPort)"
+            case .remote: return "R :\(m.localPort) → :\(m.remotePort)"
+            case .local: return ":\(m.localPort) → :\(m.remotePort)"
+            }
         }.joined(separator: ", ")
     }
 

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
@@ -356,14 +356,22 @@ class TunnelManager {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
 
-        // One forward flag per port mapping — -L for a local forward, -D for a
-        // SOCKS proxy — all carried by a single ssh process.
+        // One forward flag per port mapping — -L for a local forward, -R for a
+        // remote forward, -D for a SOCKS proxy — all carried by a single ssh
+        // process.
         var arguments = ["-N"]
         for mapping in tunnel.portMappings {
             switch mapping.forward {
             case .local:
                 arguments.append(contentsOf: [
                     "-L", "\(mapping.localHost):\(mapping.localPort):\(mapping.remoteHost):\(mapping.remotePort)"
+                ])
+            case .remote:
+                // ssh -R [bind_address:]port:host:hostport — the remote host
+                // binds `port` and forwards what it receives back to
+                // host:hostport, which is normally this Mac (localhost).
+                arguments.append(contentsOf: [
+                    "-R", "\(mapping.localHost):\(mapping.localPort):\(mapping.remoteHost):\(mapping.remotePort)"
                 ])
             case .dynamic:
                 arguments.append(contentsOf: [
@@ -396,6 +404,9 @@ class TunnelManager {
                 "-o", "StrictHostKeyChecking=no",
                 "-o", "UserKnownHostsFile=/dev/null"
             ])
+        }
+        if let proxyJump = tunnel.proxyJump?.trimmingCharacters(in: .whitespaces), !proxyJump.isEmpty {
+            arguments.append(contentsOf: ["-J", proxyJump])
         }
 
         // Destination, then robustness/hardening options. Forcing a dedicated,

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
@@ -14,6 +14,7 @@ struct TunnelDetailView: View {
         case mappingLocalHost(UUID), mappingLocalPort(UUID)
         case mappingRemoteHost(UUID), mappingRemotePort(UUID)
         case connectTimeout, aliveInterval, aliveCountMax
+        case proxyJump
     }
 
     init(tunnel: Tunnel) {
@@ -175,7 +176,7 @@ struct TunnelDetailView: View {
             } header: {
                 Text("Port Forwarding")
             } footer: {
-                Text("Each mapping adds a -L (local forward) or -D (SOCKS proxy) flag to the SSH command.")
+                Text("Each mapping adds a -L (local forward), -R (remote forward), or -D (SOCKS proxy) flag to the SSH command.")
             }
 
             Section {
@@ -251,6 +252,22 @@ struct TunnelDetailView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    LabeledContent("Jump Host") {
+                        TextField("e.g. bastion.example.com", text: Binding(
+                            get: { editedTunnel.proxyJump ?? "" },
+                            set: { editedTunnel.proxyJump = $0.isEmpty ? nil : $0 }
+                        ))
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .focused($focusedField, equals: .proxyJump)
+                        .help("Adds -J <value>. Hops through one or more intermediate hosts to reach the host above, replacing a manual multi-hop ssh. Multiple hops: user@a,user@b.")
+                    }
+                    Text("Optional. Leave blank to connect directly. Format matches ssh -J: user@host[:port][,user@host2[:port2]...]")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             } header: {
                 Text("Advanced")
             }
@@ -258,11 +275,17 @@ struct TunnelDetailView: View {
             if status == .connected {
                 Section {
                     ForEach(editedTunnel.portMappings) { mapping in
-                        if mapping.forward == .dynamic {
+                        switch mapping.forward {
+                        case .dynamic:
                             UsageRow(label: "Proxy", value: "\(mapping.localHost):\(mapping.localPort)")
                             UsageRow(label: "socks5h", value: "socks5h://\(mapping.localHost):\(mapping.localPort)")
                             UsageRow(label: "socks5", value: "socks5://\(mapping.localHost):\(mapping.localPort)")
-                        } else {
+                        case .remote:
+                            UsageRow(
+                                label: "R :\(mapping.localPort)",
+                                value: "listening on the remote host — forwards to \(mapping.remoteHost):\(mapping.remotePort) here"
+                            )
+                        case .local:
                             UsageRow(
                                 label: ":\(mapping.localPort)",
                                 value: "http://\(mapping.localHost):\(mapping.localPort)"
@@ -328,6 +351,8 @@ struct TunnelDetailView: View {
             switch mapping.forward {
             case .local:
                 cmd += " -L \(mapping.localHost):\(mapping.localPort):\(mapping.remoteHost):\(mapping.remotePort)"
+            case .remote:
+                cmd += " -R \(mapping.localHost):\(mapping.localPort):\(mapping.remoteHost):\(mapping.remotePort)"
             case .dynamic:
                 cmd += " -D \(mapping.localHost):\(mapping.localPort)"
             }
@@ -349,6 +374,9 @@ struct TunnelDetailView: View {
         }
         if tunnel.skipHostKeyCheck {
             cmd += " -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        }
+        if let proxyJump = tunnel.proxyJump?.trimmingCharacters(in: .whitespaces), !proxyJump.isEmpty {
+            cmd += " -J \(proxyJump)"
         }
         if tunnel.useAlias {
             if tunnel.port != 22 {
@@ -377,12 +405,13 @@ struct PortMappingEditor: View {
         VStack(alignment: .leading, spacing: 8) {
             Picker("Type", selection: $mapping.forward) {
                 Text("Local Forward").tag(ForwardType.local)
+                Text("Remote Forward").tag(ForwardType.remote)
                 Text("SOCKS Proxy").tag(ForwardType.dynamic)
             }
             .pickerStyle(.segmented)
             .labelsHidden()
 
-            LabeledContent(mapping.forward == .dynamic ? "Listen" : "Local") {
+            LabeledContent(mapping.forward == .dynamic ? "Listen" : (mapping.forward == .remote ? "On Remote" : "Local")) {
                 HStack(spacing: 4) {
                     TextField("Host", text: $mapping.localHost)
                         .textFieldStyle(.roundedBorder)
@@ -398,8 +427,9 @@ struct PortMappingEditor: View {
                 }
             }
 
-            if mapping.forward == .local {
-                LabeledContent("Remote") {
+            switch mapping.forward {
+            case .local, .remote:
+                LabeledContent(mapping.forward == .remote ? "Back to (usually this Mac)" : "Remote") {
                     HStack(spacing: 4) {
                         TextField("Host", text: $mapping.remoteHost)
                             .textFieldStyle(.roundedBorder)
@@ -414,7 +444,12 @@ struct PortMappingEditor: View {
                             .focused($focusedField, equals: .mappingRemotePort(mapping.id))
                     }
                 }
-            } else {
+                if mapping.forward == .remote {
+                    Text("The remote host binds this port and forwards what it receives back to the host:port below — usually localhost on this Mac.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .dynamic:
                 Text("SOCKS5 proxy — point your app or system proxy at this address.")
                     .font(.caption)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
# Add Remote Forward (-R) and ProxyJump (-J)

## Background

Two more options I'd been doing manually before this app, both turning out to be
useful enough to justify a real config field rather than typing them by hand each
time:

- I've been routing through a bastion (`ssh -J bastion target`) manually for hosts
  that aren't directly reachable, instead of having the app do it.
- A handful of my hosts need to forward a port in the *other* direction — something
  on the remote side connecting back to this Mac — which `-L`/`-D` don't cover.

## What this adds

**Remote Forward (`-R`)** — `ForwardType` gains a `.remote` case. It reuses the
existing `PortMapping` shape (`localHost`/`localPort`/`remoteHost`/`remotePort`)
since `-R`'s grammar is the same four fields as `-L`, just with the bind/forward
direction reversed: the remote host binds the port, and whatever arrives there gets
sent back to `remoteHost:remotePort` — normally `localhost` on this Mac. UI-wise,
it's a third segment in the existing Local Forward / SOCKS Proxy picker, with the
field labels and a short explanation flipping to match ("On Remote" / "Back to
(usually this Mac)").

**ProxyJump (`-J`)** — `Tunnel` gains an optional `proxyJump: String?`, passed as
`-J <value>` when non-empty, exactly matching ssh's own `-J` syntax
(`user@host[:port][,user@host2...]`) so multi-hop chains work too. Blank/nil means
"connect directly," matching today's behavior exactly.

One thing that tripped me up while testing and is worth calling out for anyone
reviewing or using this: `-J` only changes *how the SSH connection is reached* — the
jump host is just a login path, not part of the tunnel. A `-L`/`-R` mapping's
`remoteHost` is still resolved from the *final* host's perspective, not the jump
host's. I'd assumed the jump host was somehow in the data path until I actually
traced through a `-v` log together with someone helping me debug this, so I added a
line to the Jump Host field's caption to head that off for the next person.

## Implementation notes

- `hasSameConnection` now includes `proxyJump`, so editing it on a running tunnel
  triggers the same disconnect→reconnect cycle as the other connection options.
- The SSH command preview, `mappingsSummary` (sidebar/menu bar), and the
  connected-tunnel Usage section all distinguish `.remote` from `.local` — a
  remote-forwarded port isn't reachable as `http://localhost:port` the way a local
  one is, so showing that as a clickable-looking URL would be misleading.
- Both `switch` statements over `ForwardType` are exhaustive (no `default` case), so
  the compiler would have caught it if I'd missed a spot handling the new case.

## What I left out

- No UI validation of the `-J` string's format — it's passed through as typed, same
  trust level as the Host field already gets.
- No separate identity file / port override for the jump host itself — ssh's own
  `-J user@host:port` syntax already covers user and port; a different key for the
  jump host specifically would need `~/.ssh/config`, which felt like scope creep here.

## Testing

Manually tested on Apple Silicon (macOS 14) against a real two-hop setup (Mac →
bastion → internal host that's only reachable through it):

- A tunnel with `proxyJump` set successfully authenticates to the jump host, then
  the final host, then establishes the `-L` forward through it — confirmed via `-v`
  output showing `Authenticated to <jump> ... using "publickey"` followed by
  `channel_connect_stdio_fwd: <final>:<port>`
- A `.remote` mapping shows `-R` in both the command preview and the live process
  arguments
- Toggling `proxyJump` on a connected tunnel triggers a reconnect with `-J` applied
- An existing `tunnels.json` without `proxyJump` or any `.remote` mappings loads
  unchanged