### PR TITLE
feat: run shell commands on tunnel connect/disconnect

### DIFF
--- a/SSHTunnelManager/SSHTunnelManager.xcodeproj/project.pbxproj
+++ b/SSHTunnelManager/SSHTunnelManager.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A10001 /* SSHTunnelManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10001; };
 		A10002 /* Tunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10002; };
 		A10003 /* ConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10003; };
+		A10012 /* TunnelHookRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10012; };
 		A10004 /* TunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10004; };
 		A10005 /* StatusIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10005; };
 		A10006 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10006; };
@@ -23,6 +24,7 @@
 		B10001 /* SSHTunnelManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTunnelManagerApp.swift; sourceTree = "<group>"; };
 		B10002 /* Tunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tunnel.swift; sourceTree = "<group>"; };
 		B10003 /* ConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigStore.swift; sourceTree = "<group>"; };
+		B10012 /* TunnelHookRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelHookRunner.swift; sourceTree = "<group>"; };
 		B10004 /* TunnelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelManager.swift; sourceTree = "<group>"; };
 		B10005 /* StatusIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusIndicator.swift; sourceTree = "<group>"; };
 		B10006 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				B10003 /* ConfigStore.swift */,
+				B10012 /* TunnelHookRunner.swift */,
 				B10004 /* TunnelManager.swift */,
 			);
 			path = Services;
@@ -207,6 +210,7 @@
 				A10001 /* SSHTunnelManagerApp.swift in Sources */,
 				A10002 /* Tunnel.swift in Sources */,
 				A10003 /* ConfigStore.swift in Sources */,
+				A10012 /* TunnelHookRunner.swift in Sources */,
 				A10004 /* TunnelManager.swift in Sources */,
 				A10005 /* StatusIndicator.swift in Sources */,
 				A10006 /* MenuBarView.swift in Sources */,

--- a/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Models/Tunnel.swift
@@ -86,6 +86,17 @@ struct Tunnel: Identifiable, Codable, Hashable {
     // doesn't expose. nil/empty adds nothing, matching today's behavior.
     var extraOptions: String?
 
+    // Shell commands run when the tunnel connects/disconnects, via `/bin/sh -c`
+    // with tunnel context injected as environment variables ($LOCAL_PORT, $HOST,
+    // $TUNNEL_NAME, …). nil/empty runs nothing. Deliberately excluded from
+    // `hasSameConnection` so editing a hook never restarts a live tunnel.
+    var connectCommand: String?
+    var disconnectCommand: String?
+    // Controls hook behavior during the app's auto-reconnect cycling. false
+    // (default): connect runs once per manual connect, disconnect only on an
+    // intentional stop. true: both fire on every reconnect cycle.
+    var fireHooksOnReconnect: Bool
+
     /// Fallback used when a tunnel doesn't override `serverAliveInterval`.
     static let defaultServerAliveInterval = 30
     /// Fallback used when a tunnel doesn't override `serverAliveCountMax`.
@@ -107,7 +118,10 @@ struct Tunnel: Identifiable, Codable, Hashable {
         disableTCPKeepAlive: Bool = false,
         skipHostKeyCheck: Bool = false,
         proxyJump: String? = nil,
-        extraOptions: String? = nil
+        extraOptions: String? = nil,
+        connectCommand: String? = nil,
+        disconnectCommand: String? = nil,
+        fireHooksOnReconnect: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -125,6 +139,9 @@ struct Tunnel: Identifiable, Codable, Hashable {
         self.skipHostKeyCheck = skipHostKeyCheck
         self.proxyJump = proxyJump
         self.extraOptions = extraOptions
+        self.connectCommand = connectCommand
+        self.disconnectCommand = disconnectCommand
+        self.fireHooksOnReconnect = fireHooksOnReconnect
     }
 
     /// True when `other` would produce the same `ssh` invocation as `self`.
@@ -149,6 +166,7 @@ struct Tunnel: Identifiable, Codable, Hashable {
         case id, name, host, port, portMappings, identityFile, autoConnect, useAlias
         case connectTimeout, serverAliveInterval, serverAliveCountMax
         case compression, disableTCPKeepAlive, skipHostKeyCheck, proxyJump, extraOptions
+        case connectCommand, disconnectCommand, fireHooksOnReconnect
         // Legacy single-mapping fields
         case localHost, localPort, remoteHost, remotePort
     }
@@ -175,6 +193,11 @@ struct Tunnel: Identifiable, Codable, Hashable {
         proxyJump = try container.decodeIfPresent(String.self, forKey: .proxyJump)
         // Absent in older configs — nil adds no extra arguments.
         extraOptions = try container.decodeIfPresent(String.self, forKey: .extraOptions)
+        // Absent in older configs — nil runs no hook, false keeps hooks fired
+        // once per manual connect (today's absence of any hook behavior).
+        connectCommand = try container.decodeIfPresent(String.self, forKey: .connectCommand)
+        disconnectCommand = try container.decodeIfPresent(String.self, forKey: .disconnectCommand)
+        fireHooksOnReconnect = try container.decodeIfPresent(Bool.self, forKey: .fireHooksOnReconnect) ?? false
 
         if let mappings = try container.decodeIfPresent([PortMapping].self, forKey: .portMappings),
            !mappings.isEmpty {
@@ -212,6 +235,9 @@ struct Tunnel: Identifiable, Codable, Hashable {
         try container.encode(skipHostKeyCheck, forKey: .skipHostKeyCheck)
         try container.encodeIfPresent(proxyJump, forKey: .proxyJump)
         try container.encodeIfPresent(extraOptions, forKey: .extraOptions)
+        try container.encodeIfPresent(connectCommand, forKey: .connectCommand)
+        try container.encodeIfPresent(disconnectCommand, forKey: .disconnectCommand)
+        try container.encode(fireHooksOnReconnect, forKey: .fireHooksOnReconnect)
     }
 
     var mappingsSummary: String {
@@ -235,6 +261,21 @@ struct Tunnel: Identifiable, Codable, Hashable {
     /// the establish probe).
     var locallyBoundPorts: [Int] {
         portMappings.filter { $0.forward != .remote }.map(\.localPort)
+    }
+
+    /// Environment variables exposed to connect/disconnect hook commands.
+    /// Ports come from `locallyBoundPorts`, so remote (-R) forwards — which bind
+    /// on the server, not this Mac — are excluded and don't shift the indices.
+    var hookEnvironment: [String: String] {
+        let ports = locallyBoundPorts
+        var env: [String: String] = [
+            "TUNNEL_NAME": name,
+            "HOST": host,
+            "LOCAL_PORTS": ports.map(String.init).joined(separator: " "),
+        ]
+        if let first = ports.first { env["LOCAL_PORT"] = String(first) }
+        for (i, port) in ports.enumerated() { env["LOCAL_PORT_\(i + 1)"] = String(port) }
+        return env
     }
 }
 

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelHookRunner.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelHookRunner.swift
@@ -1,0 +1,63 @@
+import Foundation
+import os
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "SSHTunnelManager",
+    category: "TunnelHook"
+)
+
+/// Runs the user-defined shell commands attached to a tunnel's connect/disconnect
+/// events. Commands run via `/bin/sh -c` so pipes, `&&`, and multi-line scripts
+/// work, with tunnel context injected as environment variables ($LOCAL_PORT,
+/// $HOST, $TUNNEL_NAME, …). Fire-and-forget: success is silent, a non-zero exit
+/// (or a launch failure) is surfaced via a notification and os_log.
+enum TunnelHookRunner {
+    /// Launch `command` for `tunnel`'s `event` ("connect"/"disconnect"). A blank
+    /// command is a no-op. Runs off the main thread; never blocks the caller.
+    static func run(command: String, tunnel: Tunnel, event: String) {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        // Inherit the app's environment so PATH (and the user's session) survive —
+        // `open`, Homebrew tools, etc. rely on it. A bare dict would wipe PATH.
+        var environment = ProcessInfo.processInfo.environment
+        for (key, value) in tunnel.hookEnvironment { environment[key] = value }
+
+        let tunnelName = tunnel.name
+
+        Task.detached {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = ["-c", trimmed]
+            process.environment = environment
+
+            // Merge stdout+stderr into one pipe so the failure log carries whatever
+            // the command emitted. readDataToEndOfFile doubles as the exit wait.
+            let outputPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = outputPipe
+
+            do {
+                try process.run()
+                let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                let exitCode = process.terminationStatus
+                if exitCode != 0 {
+                    let output = String(decoding: data, as: UTF8.self)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    logger.error("""
+                        \(event, privacy: .public) hook for "\(tunnelName, privacy: .public)" \
+                        exited \(exitCode): \(output, privacy: .public)
+                        """)
+                    TunnelNotification.notifyHookFailed(tunnelName: tunnelName, event: event)
+                }
+            } catch {
+                logger.error("""
+                    Failed to launch \(event, privacy: .public) hook for \
+                    "\(tunnelName, privacy: .public)": \(error.localizedDescription, privacy: .public)
+                    """)
+                TunnelNotification.notifyHookFailed(tunnelName: tunnelName, event: event)
+            }
+        }
+    }
+}

--- a/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Services/TunnelManager.swift
@@ -67,6 +67,13 @@ enum TunnelNotification {
         post(title: tunnelName, body: "Disconnected — attempting to reconnect")
     }
 
+    /// A hook command failed. Shown unconditionally — unlike connect/disconnect
+    /// cues this is an error the user needs to see, so it isn't gated behind the
+    /// notification preference.
+    static func notifyHookFailed(tunnelName: String, event: String) {
+        post(title: tunnelName, body: "The \(event) command failed — see Console for details")
+    }
+
     private static func post(title: String, body: String) {
         let content = UNMutableNotificationContent()
         content.title = title
@@ -182,6 +189,8 @@ class TunnelManager {
     private var shouldBeConnected: Set<UUID> = [] // Tracks desired state for reconnection
     private var connectingInFlight: Set<UUID> = [] // Tunnels whose SSH process is mid-startup
     private var establishedTunnels: Set<UUID> = [] // Connections that survived the grace period (gates feedback)
+    private var connectHookFired: Set<UUID> = [] // Tunnels whose connect hook already ran this manual session (survives transient drops; cleared on intentional disconnect)
+    private var sessionEverUp: Set<UUID> = [] // Tunnels that established at least once this session and still owe a disconnect hook (survives transient drops; cleared when that hook fires)
     private var lastErrors: [UUID: String] = [:] // Why each tunnel last failed/dropped — sticky until it establishes or is stopped
     private let configStore = ConfigStore()
     private var reconnectTask: Task<Void, Never>?
@@ -533,6 +542,23 @@ class TunnelManager {
             TunnelSound.playConnected()
             TunnelNotification.notifyConnected(tunnelName: tunnelName)
         }
+        // Mark that this session came up, so an intentional stop fires the
+        // disconnect hook even if the tunnel is mid-reconnect at that moment
+        // (when `establishedTunnels` has already dropped the id). Cleared only
+        // when the disconnect hook actually fires.
+        sessionEverUp.insert(tunnelID)
+
+        // Run the connect hook. `connectHookFired` tracks first-run across a whole
+        // manual session (it isn't cleared on transient drops, unlike
+        // `establishedTunnels`), so with the toggle off the hook runs once and
+        // stays quiet through auto-reconnects.
+        guard let tunnel = tunnels.first(where: { $0.id == tunnelID }),
+              let command = tunnel.connectCommand,
+              !command.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        let firstTime = connectHookFired.insert(tunnelID).inserted
+        if tunnel.fireHooksOnReconnect || firstTime {
+            TunnelHookRunner.run(command: command, tunnel: tunnel, event: "connect")
+        }
     }
 
     private func handleProcessTermination(tunnelID: UUID, stderr: String, exitCode: Int32, terminatedBySignal: Bool) {
@@ -558,9 +584,22 @@ class TunnelManager {
             // never became "established" (silent), and a clean internal restart
             // isn't a drop — so no nuisance beeps.
             if wasEstablished && !cleanStop {
-                let tunnelName = tunnels.first(where: { $0.id == tunnelID })?.name ?? "Tunnel"
+                let droppedTunnel = tunnels.first(where: { $0.id == tunnelID })
                 TunnelSound.playDisconnected()
-                TunnelNotification.notifyDisconnected(tunnelName: tunnelName)
+                TunnelNotification.notifyDisconnected(tunnelName: droppedTunnel?.name ?? "Tunnel")
+                // A transient drop only runs the disconnect hook when the user opted
+                // into per-cycle firing; otherwise it's saved for the intentional
+                // stop in `disconnect(tunnel:)`.
+                if let droppedTunnel, droppedTunnel.fireHooksOnReconnect,
+                   let command = droppedTunnel.disconnectCommand,
+                   !command.trimmingCharacters(in: .whitespaces).isEmpty {
+                    // This drop is now paired with its disconnect hook; clear the
+                    // owed-cleanup flag so a stop before the reconnect can't fire a
+                    // second disconnect for the same down event. A successful
+                    // reconnect re-sets it in `markEstablished`.
+                    sessionEverUp.remove(tunnelID)
+                    TunnelHookRunner.run(command: command, tunnel: droppedTunnel, event: "disconnect")
+                }
             }
         } else {
             connectionStatus[tunnelID] = .disconnected
@@ -623,6 +662,20 @@ class TunnelManager {
         establishedTunnels.remove(tunnel.id)
         // A deliberate stop is not a failure — clear any recorded reason.
         lastErrors.removeValue(forKey: tunnel.id)
+
+        // This intentional stop runs the disconnect hook (regardless of the
+        // reconnect toggle — that toggle only governs transient drops), but only
+        // if the tunnel came up at least once this session, so a
+        // cancel-while-connecting doesn't fire a cleanup for a connect that never
+        // ran. `sessionEverUp` (not the momentary `establishedTunnels`) is the
+        // signal, so stopping a tunnel that's mid-reconnect still runs cleanup.
+        // Clearing `connectHookFired` lets the connect hook run again next connect.
+        connectHookFired.remove(tunnel.id)
+        if sessionEverUp.remove(tunnel.id) != nil,
+           let command = tunnel.disconnectCommand,
+           !command.trimmingCharacters(in: .whitespaces).isEmpty {
+            TunnelHookRunner.run(command: command, tunnel: tunnel, event: "disconnect")
+        }
 
         guard let pid = processIDs[tunnel.id] else {
             connectionStatus[tunnel.id] = .disconnected
@@ -715,7 +768,11 @@ class TunnelManager {
     }
 
     func deleteTunnel(_ tunnel: Tunnel) {
-        if isConnected(tunnel) {
+        // Tear down whenever the tunnel is wanted-up or has a live process — not
+        // only when it's fully `.connected` — so deleting one that's mid-reconnect
+        // still kills its ssh process and fires its disconnect hook, instead of
+        // leaking both.
+        if shouldBeConnected.contains(tunnel.id) || processIDs[tunnel.id] != nil {
             disconnect(tunnel: tunnel)
         }
         items.removeAll { $0.tunnel?.id == tunnel.id }
@@ -791,6 +848,8 @@ class TunnelManager {
         shouldBeConnected.removeAll()
         connectingInFlight.removeAll()
         establishedTunnels.removeAll()
+        connectHookFired.removeAll()
+        sessionEverUp.removeAll()
 
         let pids = Array(processIDs.values)
 

--- a/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
+++ b/SSHTunnelManager/SSHTunnelManager/Views/MainWindow/TunnelDetailView.swift
@@ -14,6 +14,7 @@ struct TunnelDetailView: View {
     // the common case, but auto-expand when one is already set.
     @State private var showJumpHost: Bool
     @State private var showExtraOptions: Bool
+    @State private var showCommands: Bool
 
     enum Field: Hashable {
         case name, host, port, identityFile, alias
@@ -21,6 +22,7 @@ struct TunnelDetailView: View {
         case mappingRemoteHost(UUID), mappingRemotePort(UUID)
         case connectTimeout, aliveInterval, aliveCountMax
         case proxyJump, extraOptions
+        case connectCommand, disconnectCommand
     }
 
     init(tunnel: Tunnel) {
@@ -28,6 +30,8 @@ struct TunnelDetailView: View {
         self._editedTunnel = State(initialValue: tunnel)
         self._showJumpHost = State(initialValue: !(tunnel.proxyJump ?? "").isEmpty)
         self._showExtraOptions = State(initialValue: !(tunnel.extraOptions ?? "").isEmpty)
+        self._showCommands = State(initialValue:
+            !(tunnel.connectCommand ?? "").isEmpty || !(tunnel.disconnectCommand ?? "").isEmpty)
     }
 
     private var status: ConnectionStatus {
@@ -307,6 +311,48 @@ struct TunnelDetailView: View {
                         .foregroundStyle(.secondary)
                 }
 
+                DisclosureGroup(isExpanded: $showCommands) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        commandEditor(
+                            label: "On connect",
+                            placeholder: "e.g. open http://localhost:$LOCAL_PORT",
+                            text: Binding(
+                                get: { editedTunnel.connectCommand ?? "" },
+                                set: { editedTunnel.connectCommand = $0.isEmpty ? nil : $0 }
+                            ),
+                            field: .connectCommand
+                        )
+
+                        commandEditor(
+                            label: "On disconnect",
+                            placeholder: "e.g. osascript -e 'display notification \"tunnel down\"'",
+                            text: Binding(
+                                get: { editedTunnel.disconnectCommand ?? "" },
+                                set: { editedTunnel.disconnectCommand = $0.isEmpty ? nil : $0 }
+                            ),
+                            field: .disconnectCommand
+                        )
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Toggle("Fire on auto-reconnect", isOn: $editedTunnel.fireHooksOnReconnect)
+                                .help("On: the commands re-run on every drop/reconnect. Off: connect runs once per connect, disconnect runs only when you stop the tunnel.")
+                            Text("Off: connect runs once, disconnect only on an intentional stop. On: both fire on every reconnect.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text("Run through /bin/sh. Available: $LOCAL_PORT (first), $LOCAL_PORT_1…, $LOCAL_PORTS, $HOST, $TUNNEL_NAME. A non-zero exit shows a notification.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.top, 2)
+                } label: {
+                    Text("Run commands")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .onTapGesture { withAnimation { showCommands.toggle() } }
+                }
+
             } header: {
                 Text("Advanced")
             }
@@ -363,6 +409,44 @@ struct TunnelDetailView: View {
             if oldValue != nil && newValue != oldValue && hasChanges {
                 saveChanges()
             }
+        }
+    }
+
+    @ViewBuilder
+    private func commandEditor(
+        label: String,
+        placeholder: String,
+        text: Binding<String>,
+        field: Field
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextEditor(text: text)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 72)
+                .scrollContentBackground(.hidden)
+                .overlay(alignment: .topLeading) {
+                    if text.wrappedValue.isEmpty {
+                        // Match NSTextView's internal line-fragment inset so the
+                        // placeholder sits exactly where the first typed character
+                        // lands. The outer .padding(6) applies to both equally.
+                        Text(placeholder)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .padding(.leading, 5)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .padding(6)
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color(nsColor: .separatorColor))
+                }
+                .focused($focusedField, equals: field)
         }
     }
 


### PR DESCRIPTION
**DISCLAIMER: This feature is done by a software engineer using AI. It has been manually code reviewed and manually tested.**

Add optional per-tunnel "on connect" / "on disconnect" shell commands, run via /bin/sh -c with tunnel context injected as environment variables ($LOCAL_PORT, $LOCAL_PORT_n, $LOCAL_PORTS, $HOST, $TUNNEL_NAME). A "Fire on auto-reconnect" toggle controls whether the hooks re-run on every reconnect cycle; by default the connect hook runs once per manual connect and the disconnect hook runs on the intentional stop, paired like mount/unmount. Non-zero exits are surfaced via a notification and os_log.

The pairing survives transient drops: a session-scoped `sessionEverUp` flag (not the momentary `establishedTunnels`) gates the disconnect hook, so stopping a tunnel while it is mid-reconnect still runs cleanup. deleteTunnel now tears down whenever the tunnel is wanted-up or has a live process, so a delete mid-reconnect fires the disconnect hook and doesn't leak the ssh process.


<img width="1100" height="1110" src="https://github.com/user-attachments/assets/85bc336f-f66e-4438-8614-74a7282e208c" />
